### PR TITLE
docs: camera review §8.1 — close Q1, Q2, Q7, Q8, Q9, Q12

### DIFF
--- a/docs/camera-calibration-review.md
+++ b/docs/camera-calibration-review.md
@@ -372,6 +372,61 @@ Depends on Q12 (FOV convention) — the fallback is currently wrong by a
 treats `fovDeg` as horizontal and most consumer spec sheets publish
 diagonal.
 
+Also depends on Q4 — the ingest path now needs to return **two** stage
+points per detection (feet + head) rather than a single center, so the
+Q1 fix must land Q4's ground-contact + height inference at the same
+time.
+
+#### Q4 — per-class height / ground-contact estimator → **code-fix (lands with Q1)**
+
+**Answer:** Yes, we need per-person height. Tracked auto-aim must be
+able to target **feet**, **center**, or **head** per action — e.g. a
+"follow-spot" action aims at the head, while a "footlight" or
+"hot-spot" action aims at the ground-contact point. A single fixed
+`z = 1700` is insufficient.
+
+**Approach (geometric, uses the calibrated camera Q1 already restores):**
+
+1. **Feet (authoritative ground point).** Project the bottom-center of
+   the YOLO bbox through the camera to the floor plane `z = 0` using
+   the homography path (when available) or the FOV ray fallback. This
+   is the stage-space point the mover aims at for "feet".
+2. **Head (inferred from bbox top).** Project the top-center pixel as
+   a ray from the camera; intersect that ray with the vertical line
+   through the feet point (same `x`, `y`, varying `z`). Solve for `z`.
+   That's the head position *and* gives us the person's height for
+   free. Works for any upright object; falls back sensibly if the ray
+   is near-parallel to the vertical.
+3. **Center.** `(feet + head) / 2`, computed on demand.
+
+**Per-class fallback (used when no homography AND camera pose
+untrusted):** static table of default heights —
+`{person: 1700, child: 1100, cat: 300, dog: 600, chair: 900,
+bicycle: 1100, suitcase: 500}` etc. Only a fallback; geometric
+inference is preferred whenever the camera is stage-mapped.
+
+**Data-model changes to `_temporal_objects[n]`:**
+- `transform.pos` — **feet** (x, y, z=0). Canonical aim-target for
+  "floor" actions and for the 3D renderer's ground footprint.
+- `transform.scale[1]` — height in mm (was hard-coded 1700).
+- New optional `_headPos` — `[x, y, z_head]` stored alongside pos when
+  the geometric inference succeeded. Missing → auto-track falls back
+  to `pos + [0, 0, scale[1]]`.
+
+**Action-model change (`/api/actions` + track-action evaluator):**
+- Add `aimTarget` enum to each track-action: `"feet" | "center" |
+  "head"` (default `"center"`).
+- `_evaluate_track_actions` at `parent_server.py:10179` resolves
+  `aimTarget` → stage XYZ from the object's `pos` / `_headPos` /
+  midpoint, then passes that to the existing mover-aim math.
+
+**Non-goal for this ticket:** bbox-height-in-pixels → real-world
+height purely from the detector (no geometry). It's tempting but
+depends on subject-to-camera distance which we don't have without the
+homography anyway. Skip.
+
+Ticket: **P1** (ships with Q1). Closes Q4 + A6.
+
 #### Q7 — homography storage: one source of truth → **code-fix**
 
 **Answer:** Collapse to `_calibrations[str(fid)]["matrix"]` as the sole
@@ -514,7 +569,6 @@ Closes #611 + B9.
 | Q | Status | Blocker |
 |---|--------|---------|
 | Q3 multi-camera fusion policy | open | Live-test step 7 (ghost-object count) |
-| Q4 per-class height / ground-contact estimator | open | Product decision — do we target non-person tracking? |
 | Q5 UX for unmapped camera | open | Depends on Q1/Q2 landing |
 | Q6 default mover-cal mode | open | Live-test steps 6 — need per-mode residuals on basement rig |
 | Q10 LM sign-confirmation probe | open | Needs synthetic-test rig (mirror-ambiguity unit test) |
@@ -526,7 +580,7 @@ Closes #611 + B9.
 
 | Priority | Ticket shape | Closes | Depends on |
 |----------|--------------|--------|------------|
-| P1 | Wire `api_objects_temporal_create` through `_pixel_to_stage` | Q1, Q2, A1, A2 | Q12 for accuracy of FOV fallback |
+| P1 | Wire `api_objects_temporal_create` through `_pixel_to_stage` + return feet/head stage points; add `aimTarget` to track-actions | Q1, Q2, Q4, A1, A2, A6 | Q12 for accuracy of FOV fallback |
 | P1 | Single-source homography: collapse to `_calibrations[str(fid)].matrix`, remove `_calibrated_cameras` dead code, migrate `fixture.homography` once | Q7, B2 | — |
 | P1 | `fovType` whitelist + unified `"diagonal"` default + honour in `_pixel_to_stage` | Q12, B9, #611 | — |
 | P2 | Demote solvePnP to diagnostic in stage-map response; rename `cameraPosition` → `cameraPositionDiagnostic`; report pnp-vs-homography disagreement | Q8, B3 | — |
@@ -558,3 +612,7 @@ Closes #611 + B9.
 - **2026-04-22** — added §2 "no backward compatibility" clause (first
   beta release). Reworded Q7 and Q9 Phase 5 to drop migration steps;
   prefer clean breaking changes over compat shims.
+- **2026-04-22** — closed Q4: geometric feet/head inference from bbox
+  + homography; new `aimTarget` enum (`feet`/`center`/`head`) on
+  track-actions. Q4 lands with Q1 (same P1 ticket). §2 (scipy
+  allowed) noted from user edit 002ec14.

--- a/docs/camera-calibration-review.md
+++ b/docs/camera-calibration-review.md
@@ -42,6 +42,12 @@ prioritised fixes.
   reuse forever. Any proposal that requires per-session ArUco gymnastics is out.
 - **No new dependencies without justification.** numpy + cv2 are in. scipy is out
   (hand-roll LM, per `project_calibration_v2_phase1.md`).
+- **No backward compatibility required.** This is the first beta release —
+  there are no shipped customers, no saved projects in the wild to preserve,
+  and no on-disk schema to migrate. Prefer the clean breaking change over a
+  compat shim. Fixes in §8 drop the word "migration" wherever it appeared in
+  the first draft: stale fields can simply be deleted, reused keys renamed in
+  place, and default JSON files regenerated from scratch.
 
 ---
 
@@ -383,15 +389,15 @@ matrix and one of them is dead code:
    line exists as pure dead code. Origin appears to be an abandoned
    refactor noted in the comment at **2757**.
 
-Migration (non-destructive):
-- On server start, for every fixture with a `fixture["homography"]`
-  but no corresponding `_calibrations[str(fid)]["matrix"]`, copy up to
-  `_calibrations` once, then strip `fixture["homography"]` and save.
+Breaking change (beta — no compat shim per §2):
 - Remove the `fixture["homography"]` write at 2777 and the fallback
-  read at 3553.
+  read at 3553 outright. Any existing `fixture.homography` field in a
+  saved layout is simply dropped on next load.
 - Delete the `_calibrated_cameras` branch at 3546 entirely.
 - Update the v2 pre-check comment block at 2755–2777 to reflect the
   single-store policy.
+- Operators re-run stage-map calibration once on upgrade; result lands
+  straight into `_calibrations[str(fid)].matrix`.
 
 Ticket: **P1** (small, mechanical, covered by `test_parent.py`). B2.
 
@@ -455,9 +461,15 @@ Proposed phased retirement (create as sub-issues under one epic):
 4. **Phase 4 — `structured_light`** (#236 is already parked out-of-scope
    per §9). Do not touch until #236 unparks.
 5. **Phase 5 — `_range_cal` record deletion.** Only after phases 1–4
-   confirm no live reads. Ship a one-shot migration that copies any
-   still-useful samples into `_mover_cal[fid].samples`, then drops the
-   `range_calibrations.json` file. B4.
+   confirm no live reads. Per §2 (beta, no compat), skip the sample-
+   migration step — just delete `range_calibrations.json`, the loader
+   at `parent_server.py:236`, and the four save sites (2903, 12034,
+   12581). Operators re-run range cal once. B4.
+
+Since there is no production data to preserve, Phase 1's
+"warn-but-keep" fallback can instead be a hard removal — measure hit
+rate only if it turns out we're still calling `affine_pan_tilt` from
+somewhere we didn't catch in grep.
 
 Ticket: **P3 (epic)**, six sub-tickets. Do not start until Q7 lands.
 
@@ -543,3 +555,6 @@ Closes #611 + B9.
 - **2026-04-22** — initial draft.
 - **2026-04-22** — §8.1 static-reading round: closed Q1, Q2, Q7, Q8, Q9, Q12.
   Five P1/P2 tickets + one P3 epic proposed. No code changes yet.
+- **2026-04-22** — added §2 "no backward compatibility" clause (first
+  beta release). Reworded Q7 and Q9 Phase 5 to drop migration steps;
+  prefer clean breaking changes over compat shims.

--- a/docs/camera-calibration-review.md
+++ b/docs/camera-calibration-review.md
@@ -604,7 +604,60 @@ Closes #611 + B9.
 
 ---
 
-## 10. Change log
+## 10. Related open issues (cross-reference)
+
+Audit of 84 open issues on 2026-04-22; 43 touched camera/calibration
+keywords. This table is the actionable subset — what to close, update,
+or cross-link when each §8.1 fix lands. Everything else (#569 camera HW
+compat, #293/#291 auto-reconnect, #203 camera OTA, #573 screenshot
+chores, #307/#306 unrelated features) is orthogonal.
+
+### 10.1 Will be closed by §8.1 fixes
+
+| Issue | Title (short) | Closed by | Notes |
+|-------|--------------|-----------|-------|
+| **#611** | Fixture PUT silently drops fovType | P1 Q12 | Already cited in §8.1 Q12. Close when the PR merges. |
+| **#612** | Marker placement UI — live per-camera coverage in Layout | Q11 (when answered) | Exact duplicate of Q11. Once Q11 closes, `#612` is the implementation ticket — keep that number, close on merge. |
+| **#357** | Mover cal discovery doesn't detect beam at computed initial aim | Q6 (markers-mode default) | The legacy-discovery failure mode disappears once Q6 picks markers-mode; verify with live-test step 6, then close. |
+| **#423** | YOLO not detecting `chair` class in tracking | P1 Q4 | Chair goes into the per-class fallback table (900 mm). Update the issue to explain class filter vs model coverage — user may be hitting the allowlist, not the model. |
+
+### 10.2 Must update (comment / re-scope)
+
+| Issue | Title (short) | Why update |
+|-------|--------------|-----------|
+| **#610** | Mover cal without operator pre-knowledge | Already the motivating ticket for markers-mode. Comment with a link to §8.1 Q6 + the upcoming Q6 live-test results, so #610's "done" bar is the markers-mode default. |
+| **#600** | Swap ry ↔ rz on camera/fixture rotation (breaking) | **Coordination required.** Our P1 Q1+Q4 patch uses `_rotation_to_aim` / `camera_math.build_camera_to_stage(tilt, pan, roll)` with the **current** ordering. If #600 lands first, our fixes adopt the new order at the start; if after, a single rename sweep updates all `rotation=[tilt, pan, roll]` call-sites plus this doc's §3.4 convention. Either order is fine — just don't interleave. Comment so whoever picks it up knows. |
+| **#597** | Advanced Scan — clear per-camera intrinsic / ArUco cal | After P1 Q7 lands, "clear" has **one** store to touch (`_calibrations[str(fid)]`) instead of two. Update the spec to reflect single-store, and drop any language about `fixture.homography`. |
+| **#484** | Gyro/phone controller: stage-space orientation architecture | Downstream consumer of `ParametricFixtureModel.inverse`. Mention that P3 Q9 Phase 1 (`mover_control.affine_pan_tilt` fallback removal) will ripple into the gyro path. |
+| **#474** | Gyro controller: absolute stage-space orientation mapping | Same as #484 — one aim stack after Q9. |
+| **#427** | Android pointer mode — 3D spatial aiming | Same as #484/#474. Explicitly note it should target the v2 stack only — do not reintroduce `affine_pan_tilt` in new code. |
+| **#510** | Android calibrate locks against server-assumed aim | Peripheral but worth a comment: the single-store homography (Q7) makes the server's "known aim" less ambiguous. Re-evaluate after P1 Q7 ships. |
+
+### 10.3 Cross-link to Q14 end-to-end regression test
+
+Q14 (still open) should absorb the scope of these existing tickets
+rather than a fresh issue:
+
+| Issue | Title (short) | Fit |
+|-------|--------------|-----|
+| **#533** | End to End Testing | Parent epic — Q14's deliverable lands here. |
+| **#409** | Live show test session — simulated person tracking | Exact mocked-pipeline spec that Q14 should produce. Keep #409 as the spec issue; Q14 ticket implements it. |
+| **#277** | End-to-end show regression — weekly Playwright | Already-scoped regression harness. Q14's camera-specific tests plug into this. |
+| **#280** | Regression test runner — weekly CI harness | Infra for #277. Orthogonal but Q14's tests ride on it. |
+
+### 10.4 No action
+
+Mentioned only to confirm they were reviewed and are not affected:
+
+- **#418** — Android 3D view coordinate space wrong. May be related to
+  #600 (axis convention) but not to §8.1 fixes. No cross-link needed.
+- **#595** — Gemini AI depth/reconstruction review. Out of scope per §9.
+- **#569**, **#293**, **#291**, **#203**, **#573**, **#307**, **#306** —
+  orthogonal.
+
+---
+
+## 11. Change log
 
 - **2026-04-22** — initial draft.
 - **2026-04-22** — §8.1 static-reading round: closed Q1, Q2, Q7, Q8, Q9, Q12.
@@ -616,3 +669,8 @@ Closes #611 + B9.
   + homography; new `aimTarget` enum (`feet`/`center`/`head`) on
   track-actions. Q4 lands with Q1 (same P1 ticket). §2 (scipy
   allowed) noted from user edit 002ec14.
+- **2026-04-22** — added §10 "Related open issues" cross-reference.
+  4 issues close with §8.1 fixes (#611, #612, #357, #423); 7 need
+  updates (#610, #600, #597, #484, #474, #427, #510); 4 cross-link
+  to Q14 (#533, #409, #277, #280). No GitHub comments posted yet —
+  table is advisory until we approve §8.1.

--- a/docs/camera-calibration-review.md
+++ b/docs/camera-calibration-review.md
@@ -320,9 +320,205 @@ All deliverables land either in this file (§8+) or as issues in the
 
 ---
 
-## 8. Findings (to be filled in during review)
+## 8. Findings
 
-_Empty — will be populated as each question is answered._
+### 8.1 Static-reading round (2026-04-22)
+
+Six questions closed by grep/read only — no hardware required. Each cites the
+evidence line numbers against the snapshot in §3 / §4.
+
+#### Q1 — pixel→stage mapping in the tracker-ingest endpoint → **code-fix**
+
+**Answer:** The current mapping is *not* acceptable for any real install. It
+must be replaced before further auto-track work, but the fix is trivial because
+the correct helper already exists and is used elsewhere.
+
+Evidence (`desktop/shared/parent_server.py`):
+- `api_objects_temporal_create` at **7206–7232** runs exactly the back-wall
+  proportional `pos = [sw·(1-cx), sd·(1-cy), 0]`. It ignores camera position,
+  rotation, FOV, and any persisted homography. Z hard-coded 0, height 1700,
+  depth 400.
+- `_pixel_to_stage` at **1888** already does the right thing: homography
+  first (`_calibrations[fid].matrix`), ground-plane projection fallback using
+  `_rotation_to_aim` + `fovDeg`. Identical helper chain that `/api/cameras/<id>/scan`
+  uses at **2027**.
+- Confirms A1 and A2 — the ingest path was written before `_pixel_to_stage`
+  was generalised, and the wire-up was simply missed.
+
+**Fix shape:** Replace the inline block at 7218–7232 with a single call to
+`_pixel_to_stage([{x,y,w,h,label,confidence}], cam_fixture, fw, fh)[0]`,
+using its returned stage coords. Keep the `cameraId`/`pixelBox`/`frameSize`
+contract on the wire. Ticket: **P1**, citations Q1, Q2, A1, A2.
+
+#### Q2 — calibrated fallback vs hard-gate homography → **code-fix (merges with Q1)**
+
+**Answer:** A calibrated fallback already exists inside `_pixel_to_stage`
+(homography-or-FOV-projection). Once Q1 is wired, tracking degrades
+gracefully: homography when surveyed, FOV ground-plane otherwise, raw
+pixel passthrough only when the camera has no stage position at all
+(line **1917** — `dist < 1`). Therefore the hard-gate option is
+unnecessary. Keep a UI warning when `_calibrations.get(str(fid))` is
+absent so operators know they're on the weaker fallback, but don't
+refuse to start.
+
+Depends on Q12 (FOV convention) — the fallback is currently wrong by a
+`cos(diagonal/2)/cos(horizontal/2)` factor because `_pixel_to_stage`
+treats `fovDeg` as horizontal and most consumer spec sheets publish
+diagonal.
+
+#### Q7 — homography storage: one source of truth → **code-fix**
+
+**Answer:** Collapse to `_calibrations[str(fid)]["matrix"]` as the sole
+writer and reader. There are currently **three** names for the same
+matrix and one of them is dead code:
+
+1. `_calibrations[str(fid)]["matrix"]` — written at **2761**, read by
+   `_pixel_to_stage` at **1895**.
+2. `fixture["homography"]` — written at **2777** (mirror), read at
+   **3553** as fallback in `_mover_cal_thread_v2_body`.
+3. `_calibrated_cameras` — referenced at **3546** with a
+   `if "_calibrated_cameras" in globals()` guard. `grep` shows the
+   symbol is **never defined** anywhere in `parent_server.py`. The
+   guard always evaluates False, so `cam_cal` is always None and the
+   line exists as pure dead code. Origin appears to be an abandoned
+   refactor noted in the comment at **2757**.
+
+Migration (non-destructive):
+- On server start, for every fixture with a `fixture["homography"]`
+  but no corresponding `_calibrations[str(fid)]["matrix"]`, copy up to
+  `_calibrations` once, then strip `fixture["homography"]` and save.
+- Remove the `fixture["homography"]` write at 2777 and the fallback
+  read at 3553.
+- Delete the `_calibrated_cameras` branch at 3546 entirely.
+- Update the v2 pre-check comment block at 2755–2777 to reflect the
+  single-store policy.
+
+Ticket: **P1** (small, mechanical, covered by `test_parent.py`). B2.
+
+#### Q8 — solvePnP path in stage-map → **code-fix (demote to diagnostic)**
+
+**Answer:** Keep `cv2.findHomography` as the canonical output; downgrade
+`solvePnP` to diagnostic-only, and stop exposing its derived
+`cameraPosition` as a primary field.
+
+Evidence at **2663–2721**:
+- solvePnP runs first (lines 2663–2690) purely to derive `cam_pos` for
+  "operator sanity check" display.
+- The exported homography is unconditionally overwritten by the direct
+  `cv2.findHomography(img_pts, stage_pts_xy)` result at **2715–2717**.
+  The pose-derived fallback at **2720–2721** only runs inside an
+  `except` — it's unreachable in practice for clean ArUco corners.
+- Comments at 2698–2710 explicitly state that the direct homography is
+  "strictly better" for coplanar floor markers; the code agrees.
+
+So solvePnP is already second-class; the confusion is in the response
+payload, not the math. Fix:
+- Rename `cameraPosition` / `cameraPosStage` keys to
+  `cameraPositionDiagnostic` (or nest under `diagnostics.pnp`) so SPA
+  consumers stop treating it as authoritative.
+- Keep running solvePnP (cheap) and report its reprojection error
+  alongside the findHomography RMS. If the two disagree by more than
+  ~2× expected, surface a warning — it's the best we have for catching
+  mirror-pose ambiguity.
+- Drop the stale "strategy" comment at 2621; the code no longer has
+  parallel paths the way the comment implies.
+
+Ticket: **P2**. B3.
+
+#### Q9 — retire v1 legacy helpers → **defer with deprecation schedule**
+
+**Answer:** Cannot delete yet. The legacy helpers have **seven** live
+callers across three files. Retirement is a multi-PR project.
+
+Live callers (from grep):
+
+| Symbol | Callers |
+|--------|---------|
+| `affine_pan_tilt` | `mover_control.py:363`, `bake_engine.py:672`, `parent_server.py:4502, 8606, 8610, 10301` |
+| `affine_stage_point` | `parent_server.py:8305` |
+| `pan_tilt_to_ray` | `structured_light.py:55`, `parent_server.py:7911` (import), `8320`, `9464` |
+| `_range_cal` / `range_calibrations` | `parent_server.py:236` (load), `2903`, `12034`, `12581` (saves) |
+
+Proposed phased retirement (create as sub-issues under one epic):
+
+1. **Phase 1 — `mover_control.aim_to_pan_tilt`** (user-facing aim path).
+   It already prefers `ParametricFixtureModel` when `_mover_models[fid]`
+   is fit; the `affine_pan_tilt` call at `mover_control.py:363` is the
+   last-resort fallback. Convert the fallback to emit a warning when
+   used, so we can measure real-world hit rate.
+2. **Phase 2 — `bake_engine`** (offline, so cheap to test). Swap to
+   `ParametricFixtureModel` with per-fixture cached model. Regression
+   test: `test_timeline_bake.py`.
+3. **Phase 3 — `parent_server` debug/preview routes** (`8305, 8606,
+   10301`). These back SPA "where will this aim land?" previews. The
+   v2 model's `inverse` already covers this; port and delete the imports.
+4. **Phase 4 — `structured_light`** (#236 is already parked out-of-scope
+   per §9). Do not touch until #236 unparks.
+5. **Phase 5 — `_range_cal` record deletion.** Only after phases 1–4
+   confirm no live reads. Ship a one-shot migration that copies any
+   still-useful samples into `_mover_cal[fid].samples`, then drops the
+   `range_calibrations.json` file. B4.
+
+Ticket: **P3 (epic)**, six sub-tickets. Do not start until Q7 lands.
+
+#### Q12 — `fovType` dropped by fixture PUT → **code-fix (and doc-fix)**
+
+**Answer:** Two independent bugs confirmed:
+
+1. **`fovType` is silently dropped.** The PUT whitelist at
+   `parent_server.py:1451–1458` lists `"fovDeg"` but **not** `"fovType"`.
+   Any client that sends `fovType` in the body has it ignored. This is
+   #611 as filed.
+
+2. **Default inconsistency across consumers.** `fovType` default
+   varies by reader:
+   - `parent_server.py:5235` — defaults to **`"diagonal"`**
+     (`_aruco_stage_map_simple`).
+   - `parent_server.py:5913, 5916, 5950` — default **`"horizontal"`**
+     (stereo/triangulation path).
+   - `_pixel_to_stage` at **1888–1997** uses `fovDeg` directly as
+     horizontal half-angle — ignores `fovType` entirely.
+
+   For the basement rig the EMEET 4K spec sheet publishes 90° as
+   *diagonal*. A horizontal-default consumer treating 90° as horizontal
+   overestimates horizontal FOV by cos(diag/2)/cos(horiz/2) ≈ 12–15%.
+   That's the cos-factor error flagged in B9.
+
+**Fix shape:**
+- Add `"fovType"` to the whitelist at 1454.
+- Validate: must be one of `{"diagonal", "horizontal", "vertical"}`.
+- Unify default to **`"diagonal"`** (consumer spec sheets use diagonal).
+- Make `_pixel_to_stage` read `fovType` and convert to horizontal
+  half-angle internally via `camera_math` (add `normalise_fov(fov_deg,
+  fov_type, aspect)` if it doesn't exist yet).
+- Update `docs/camera.md` and `project_basement_rig.md` to reflect
+  "diagonal is the canonical input; everything else is derived".
+
+Ticket: **P1** (ships with Q1/Q2; Q2 fallback accuracy depends on it).
+Closes #611 + B9.
+
+### 8.2 Still-open questions (need live test or more digging)
+
+| Q | Status | Blocker |
+|---|--------|---------|
+| Q3 multi-camera fusion policy | open | Live-test step 7 (ghost-object count) |
+| Q4 per-class height / ground-contact estimator | open | Product decision — do we target non-person tracking? |
+| Q5 UX for unmapped camera | open | Depends on Q1/Q2 landing |
+| Q6 default mover-cal mode | open | Live-test steps 6 — need per-mode residuals on basement rig |
+| Q10 LM sign-confirmation probe | open | Needs synthetic-test rig (mirror-ambiguity unit test) |
+| Q11 marker-coverage UX | open | UX-fix; scope after Q6 |
+| Q13 "camera health" dashboard | open | Scope after Q1/Q7/Q12 |
+| Q14 end-to-end regression test | open | Scope after Q1/Q7/Q12 — test shape depends on final ingest contract |
+
+### 8.3 Prioritised fix list (from 8.1)
+
+| Priority | Ticket shape | Closes | Depends on |
+|----------|--------------|--------|------------|
+| P1 | Wire `api_objects_temporal_create` through `_pixel_to_stage` | Q1, Q2, A1, A2 | Q12 for accuracy of FOV fallback |
+| P1 | Single-source homography: collapse to `_calibrations[str(fid)].matrix`, remove `_calibrated_cameras` dead code, migrate `fixture.homography` once | Q7, B2 | — |
+| P1 | `fovType` whitelist + unified `"diagonal"` default + honour in `_pixel_to_stage` | Q12, B9, #611 | — |
+| P2 | Demote solvePnP to diagnostic in stage-map response; rename `cameraPosition` → `cameraPositionDiagnostic`; report pnp-vs-homography disagreement | Q8, B3 | — |
+| P3 (epic) | Retire v1 legacy helpers — 5-phase plan in Q9 | Q9, B4 | Q7 must land first |
 
 ---
 
@@ -345,3 +541,5 @@ _Empty — will be populated as each question is answered._
 ## 10. Change log
 
 - **2026-04-22** — initial draft.
+- **2026-04-22** — §8.1 static-reading round: closed Q1, Q2, Q7, Q8, Q9, Q12.
+  Five P1/P2 tickets + one P3 epic proposed. No code changes yet.

--- a/docs/camera-calibration-review.md
+++ b/docs/camera-calibration-review.md
@@ -40,7 +40,7 @@ prioritised fixes.
 - **Operator-first, not algorithm-first.** Per `feedback_cal_algorithm.md`: the
   operator will not run a multi-frame chessboard wizard. Survey markers once,
   reuse forever. Any proposal that requires per-session ArUco gymnastics is out.
-- **No new dependencies without justification.** numpy + cv2 are in. scipy is out
+- **No new dependencies without justification.** numpy + cv2 are in. scipy can be used if needed
   (hand-roll LM, per `project_calibration_v2_phase1.md`).
 - **No backward compatibility required.** This is the first beta release —
   there are no shipped customers, no saved projects in the wild to preserve,


### PR DESCRIPTION
Static-reading round of the camera calibration review. Six questions
closed without hardware. Key finds:

- Q1/A1 confirmed: api_objects_temporal_create skips _pixel_to_stage
  and runs a back-wall proportional mapping that ignores rotation,
  FOV, and the persisted homography. Fix is a one-line wire-up since
  the right helper already exists.
- Q7/B2 expanded: there are THREE storage names for the homography
  (_calibrations[fid].matrix, fixture.homography, and _calibrated_
  cameras). The third is referenced at parent_server.py:3546 but
  never defined — pure dead code guarded by a paranoid globals()
  check. Collapse to one store, migrate, delete the dead branch.
- Q8/B3: solvePnP is already second-class (findHomography always
  overwrites); the confusion is in the response payload, not the
  math. Rename cameraPosition → cameraPositionDiagnostic.
- Q9/B4: 7 live callers of the v1 helpers across 3 files. Proposed
  5-phase retirement; do not start until Q7 lands.
- Q12/B9: fovType is silently dropped by the fixture PUT whitelist
  (#611) AND consumers default inconsistently (diagonal vs
  horizontal). Unify default to diagonal; honour in _pixel_to_stage.

Five P1/P2 tickets and one P3 epic proposed. No code changes.

https://claude.ai/code/session_01HbHa2zbq4wkZ6JYHoSmbsC